### PR TITLE
Add macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,22 @@
    pip install -r requirements.txt
    ```
 ## 4. **Запускайте программу**
-Когда всё готово, запускаем основную программу:
-   ```bash
-   run_transcriber.bat
-   ```
+Когда всё готово, запускаем основную программу.
+
+**Windows**
+
+```bash
+run_transcriber.bat
+```
+
+**macOS**
+
+```bash
+bash run_transcriber.command
+```
+
+## Отличия macOS и Windows версий
+
+Обе версии работают одинаково и используют `transcriber_pyside6.py`. Разница
+заключается только в стартовых скриптах. В Windows запускайте `run_transcriber.bat`,
+а в macOS — `run_transcriber.command`, который нужно выполнить через `bash`.

--- a/run_transcriber.command
+++ b/run_transcriber.command
@@ -1,0 +1,3 @@
+#!/bin/bash
+python3 "$(dirname "$0")/transcriber_pyside6.py"
+read -n 1 -s -r -p "Нажмите любую клавишу для выхода..."


### PR DESCRIPTION
## Summary
- add launch script for macOS
- document how to run on macOS and explain difference with Windows version

## Testing
- `python -m py_compile transcriber_pyside6.py`
- `bash ./run_transcriber.command` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_686f9a0e84d88326baf75f20e49f948e